### PR TITLE
Allow a config file to specify sandbox mode

### DIFF
--- a/app/Console/Commands/repl.php
+++ b/app/Console/Commands/repl.php
@@ -191,6 +191,7 @@ class repl extends Command {
             'salesforce_consumer_key' => $this->salesforce_consumer_key,
             'salesforce_consumer_secret' => $this->salesforce_consumer_secret,
             'salesforce_security_token' => $this->salesforce_security_token,
+            'sandbox' => $this->sandbox ?? false,
         ];
     }
 

--- a/app/Salesforce.php
+++ b/app/Salesforce.php
@@ -124,7 +124,9 @@ class Salesforce {
             'password' => $salesforcePass
         ];
 
-        $resp = $this->client->request('POST', 'https://login.salesforce.com/services/oauth2/token', [
+        $authUrl = $this->getenv('sandbox') ? 'https://test.salesforce.com' : 'https://login.salesforce.com';
+
+        $resp = $this->client->request('POST', "$authUrl/services/oauth2/token", [
                 'form_params' => $params
                 ]);
 

--- a/sample.config.ini
+++ b/sample.config.ini
@@ -4,3 +4,5 @@ salesforce_pass = password
 salesforce_consumer_key = key
 salesforce_consumer_secret = secret
 salesforce_security_token = token
+# Uncomment to use https://test.salesforce.com for login. 
+# sandbox = 1 


### PR DESCRIPTION
This lets the repl use https://test.salesforce.com as the auth url
instead of the production https://login.salesforce.com
